### PR TITLE
Improve Error handling and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,11 +2066,13 @@ name = "oracle-client"
 version = "0.1.0"
 dependencies = [
  "bls-signatures",
+ "env_logger",
  "eth2_ssz_derive",
  "ethereum_ssz",
  "ethers",
  "eyre",
  "futures",
+ "log",
  "rand",
  "rand_chacha",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 
 [dependencies]
 bls-signatures = "0.14.0"
+env_logger = "0.9.0"
 eth2_ssz_derive = "0.3.0"
 ethereum_ssz = "0.5.2"
 ethers = {version = "2.0.4", features = ["ws"]}
 eyre = "0.6.8"
 futures = "0.3.28"
+log = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = {version = "1.0.163", features = ["derive"]}

--- a/src/message_broadcaster/log.rs
+++ b/src/message_broadcaster/log.rs
@@ -5,7 +5,7 @@ use crate::message_broadcaster::{MessageBroadcaster, PriceMessage};
 pub struct LogMessageBroadcaster {}
 
 impl MessageBroadcaster for LogMessageBroadcaster {
-    fn broadcast(&self, msg: PriceMessage) -> Result<()>{
+    fn broadcast(&self, msg: PriceMessage) -> Result<()> {
         log::debug!("Broadcasting message: {:?}", msg);
         Ok(())
     }

--- a/src/message_broadcaster/log.rs
+++ b/src/message_broadcaster/log.rs
@@ -1,9 +1,12 @@
+use eyre::Result;
+
 use crate::message_broadcaster::{MessageBroadcaster, PriceMessage};
 
 pub struct LogMessageBroadcaster {}
 
 impl MessageBroadcaster for LogMessageBroadcaster {
-    fn broadcast(&self, msg: PriceMessage) {
-        println!("Broadcasting message: {:?}", msg);
+    fn broadcast(&self, msg: PriceMessage) -> Result<()>{
+        log::debug!("Broadcasting message: {:?}", msg);
+        Ok(())
     }
 }

--- a/src/message_broadcaster/mod.rs
+++ b/src/message_broadcaster/mod.rs
@@ -1,3 +1,5 @@
+use eyre::Result;
+
 use crate::price_provider::Price;
 use bls_signatures::Signature;
 
@@ -10,5 +12,5 @@ pub struct PriceMessage {
 }
 
 pub trait MessageBroadcaster {
-    fn broadcast(&self, msg: PriceMessage);
+    fn broadcast(&self, msg: PriceMessage) -> Result<()>;
 }

--- a/src/price_provider/gofer/mod.rs
+++ b/src/price_provider/gofer/mod.rs
@@ -1,4 +1,5 @@
 use crate::price_provider::{Price, PriceProvider, PRECISION_FACTOR};
+use eyre::Result;
 use std::process::Command;
 
 mod types;
@@ -8,31 +9,28 @@ pub struct GoferPriceProvider {
 }
 
 impl GoferPriceProvider {
-    pub fn new(gofer_cmd: Option<&str>) -> GoferPriceProvider {
+    pub fn new(gofer_cmd: Option<&str>) -> Result<GoferPriceProvider> {
         match gofer_cmd {
-            Some(cmd) => GoferPriceProvider {
+            Some(cmd) => Ok(GoferPriceProvider {
                 gofer_cmd: cmd.to_string(),
-            },
-            None => GoferPriceProvider {
-                gofer_cmd: std::env::var("GOFER_CMD")
-                    .expect("Neither GOFER_CMD env variable nor gofer_cmd argument was provided"),
-            },
+            }),
+            None => Ok(GoferPriceProvider {
+                gofer_cmd: std::env::var("GOFER_CMD")?
+            }),
         }
     }
 }
 
 impl PriceProvider for GoferPriceProvider {
-    fn get_price(&self) -> Option<Price> {
+    fn get_price(&self) -> Result<Price> {
         let output = Command::new(&self.gofer_cmd)
             .arg("prices")
             .arg("--norpc")
             .arg("ETH/USD")
-            .output()
-            .expect("failed to execute process");
-        // TODO: Replace panics with proper error handling
-        let string_output = String::from_utf8(output.stdout).expect("Error decoding");
-        let data: types::Root = serde_json::from_str(&string_output).expect("Error parsing");
+            .output()?;
+        let string_output = String::from_utf8(output.stdout)?;
+        let data: types::Root = serde_json::from_str(&string_output)?;
         let value = (data.price * PRECISION_FACTOR as f64) as u64;
-        Some(Price { value })
+        Ok(Price { value })
     }
 }

--- a/src/price_provider/gofer/mod.rs
+++ b/src/price_provider/gofer/mod.rs
@@ -15,7 +15,7 @@ impl GoferPriceProvider {
                 gofer_cmd: cmd.to_string(),
             }),
             None => Ok(GoferPriceProvider {
-                gofer_cmd: std::env::var("GOFER_CMD")?
+                gofer_cmd: std::env::var("GOFER_CMD")?,
             }),
         }
     }

--- a/src/price_provider/mod.rs
+++ b/src/price_provider/mod.rs
@@ -1,3 +1,4 @@
+use eyre::Result;
 use ssz_derive::{Decode, Encode};
 
 pub mod gofer;
@@ -13,5 +14,5 @@ pub struct Price {
 }
 
 pub trait PriceProvider {
-    fn get_price(&self) -> Option<Price>;
+    fn get_price(&self) -> Result<Price>;
 }

--- a/src/signature_provider/mod.rs
+++ b/src/signature_provider/mod.rs
@@ -1,6 +1,8 @@
+use eyre::Result;
+
 use bls_signatures::Signature;
 pub mod private_key;
 
 pub trait SignatureProvider {
-    fn sign(&self, msg: &[u8]) -> Option<Signature>;
+    fn sign(&self, msg: &[u8]) -> Result<Signature>;
 }

--- a/src/signature_provider/private_key.rs
+++ b/src/signature_provider/private_key.rs
@@ -1,3 +1,5 @@
+use eyre::Result;
+
 use crate::signature_provider::SignatureProvider;
 use bls_signatures::{PrivateKey, Signature};
 use rand::SeedableRng;
@@ -11,12 +13,13 @@ impl PrivateKeySignatureProvider {
     pub fn random() -> PrivateKeySignatureProvider {
         let mut rng = ChaCha8Rng::seed_from_u64(12);
         let private_key = PrivateKey::generate(&mut rng);
+        log::debug!("Generated random private key associated with public key: {:?}", private_key.public_key());
         PrivateKeySignatureProvider { private_key }
     }
 }
 
 impl SignatureProvider for PrivateKeySignatureProvider {
-    fn sign(&self, msg: &[u8]) -> Option<Signature> {
-        Some(self.private_key.sign(msg))
+    fn sign(&self, msg: &[u8]) -> Result<Signature> {
+        Ok(self.private_key.sign(msg))
     }
 }

--- a/src/signature_provider/private_key.rs
+++ b/src/signature_provider/private_key.rs
@@ -13,7 +13,10 @@ impl PrivateKeySignatureProvider {
     pub fn random() -> PrivateKeySignatureProvider {
         let mut rng = ChaCha8Rng::seed_from_u64(12);
         let private_key = PrivateKey::generate(&mut rng);
-        log::debug!("Generated random private key associated with public key: {:?}", private_key.public_key());
+        log::debug!(
+            "Generated random private key associated with public key: {:?}",
+            private_key.public_key()
+        );
         PrivateKeySignatureProvider { private_key }
     }
 }

--- a/src/slot_provider/mined_blocks.rs
+++ b/src/slot_provider/mined_blocks.rs
@@ -1,5 +1,5 @@
 use ethers::providers::{Middleware, Provider, StreamExt, Ws};
-use eyre::Result;
+use eyre::{Error, Result, WrapErr};
 use futures::Future;
 
 use crate::slot_provider::{Slot, SlotProvider};
@@ -9,28 +9,38 @@ pub struct MinedBlocksSlotProvider {
 }
 
 impl MinedBlocksSlotProvider {
-    pub async fn new() -> MinedBlocksSlotProvider {
+    pub async fn new() -> Result<MinedBlocksSlotProvider> {
         let provider = Provider::<Ws>::connect(
             "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27",
         )
-        .await
-        .expect("Error connecting to Infura");
-        MinedBlocksSlotProvider { provider }
+        .await?;
+        Ok(MinedBlocksSlotProvider { provider })
     }
 }
 
 impl SlotProvider for MinedBlocksSlotProvider {
     fn run_for_every_slot<F>(&self, f: F) -> Box<dyn Future<Output = Result<()>> + Unpin + '_>
     where
-        F: Fn(Slot) + 'static,
+        F: Fn(Slot) -> Result<()> + 'static,
     {
         Box::new(Box::pin(async move {
             let block_stream = self.provider.subscribe_blocks().await?;
-            let mut slot_stream = block_stream.map(|block| Slot {
-                number: block.number.unwrap().as_u64(),
-            });
-            while let Some(slot) = slot_stream.next().await {
-                f(slot);
+            let mut slot_stream = block_stream.map(|block| -> Result<Slot>{ Ok(Slot {
+                number: block.number.ok_or(Error::msg("block.number is none"))?.as_u64(),
+            })});
+            while let Some(slot_result) = slot_stream.next().await {
+                let slot = match slot_result {
+                    Ok(slot) => slot,
+                    Err(e) => {
+                        log::error!("Error getting slot: {:?}", e);
+                        continue;
+                    }
+                };
+                let slot_number = slot.number;
+                match f(slot).wrap_err(format!("Failed to run for slot: {}", slot_number)) {
+                    Ok(_) => log::info!("Ran succesfully for slot {}", slot_number),
+                    Err(e) => log::error!("{:?}", e),
+                };
             }
             Ok(())
         }))

--- a/src/slot_provider/mined_blocks.rs
+++ b/src/slot_provider/mined_blocks.rs
@@ -25,9 +25,14 @@ impl SlotProvider for MinedBlocksSlotProvider {
     {
         Box::new(Box::pin(async move {
             let block_stream = self.provider.subscribe_blocks().await?;
-            let mut slot_stream = block_stream.map(|block| -> Result<Slot>{ Ok(Slot {
-                number: block.number.ok_or(Error::msg("block.number is none"))?.as_u64(),
-            })});
+            let mut slot_stream = block_stream.map(|block| -> Result<Slot> {
+                Ok(Slot {
+                    number: block
+                        .number
+                        .ok_or(Error::msg("block.number is none"))?
+                        .as_u64(),
+                })
+            });
             while let Some(slot_result) = slot_stream.next().await {
                 let slot = match slot_result {
                     Ok(slot) => slot,

--- a/src/slot_provider/mod.rs
+++ b/src/slot_provider/mod.rs
@@ -11,5 +11,5 @@ pub struct Slot {
 pub trait SlotProvider {
     fn run_for_every_slot<F>(&self, f: F) -> Box<dyn Future<Output = Result<()>> + Unpin + '_>
     where
-        F: Fn(Slot) + 'static;
+        F: Fn(Slot) -> Result<()> + 'static;
 }


### PR DESCRIPTION
1. Remove all "expect" and "unwrap" calls and use `eyre` error handling / formatting, avoiding crashes and logging out informative error reports instead. (closes #6 )
2. Add logging with `env_logger` (closes #5 )

This means you now have to add `RUST_LOG` env variable to see logs.

Example with error report: (produced by specifying an invalid `GOFER_CMD` path)
<img width="987" alt="image" src="https://github.com/ultrasoundmoney/oracle-client/assets/15629702/4c85d8bd-5ea7-4339-ba5f-477e50db06b6">
