### PR TITLE
refactor(attestation_scheduler): simplify bounds

### DIFF
--- a/src/attestation_scheduler.rs
+++ b/src/attestation_scheduler.rs
@@ -60,15 +60,15 @@ pub struct SystemClockAttestationScheduler {
 
 impl SystemClockAttestationScheduler {
     pub fn new(
-        message_broadcaster: impl MessageBroadcaster + 'static + Send + Sync,
+        message_broadcaster: Box<dyn MessageBroadcaster>,
         message_generator: MessageGenerator,
-        price_provider: impl PriceProvider + 'static + Send + Sync,
+        price_provider: Box<dyn PriceProvider>,
         slots_to_run: Option<u64>,
     ) -> Self {
         Self {
-            message_broadcaster: Box::new(message_broadcaster),
+            message_broadcaster,
             message_generator,
-            price_provider: Box::new(price_provider),
+            price_provider,
             slots_to_run: Arc::new(Mutex::new(slots_to_run)),
         }
     }
@@ -223,9 +223,9 @@ mod tests {
             JsonFileMessageBroadcaster::new(Some("test_data/output".to_string())).unwrap();
 
         let attestation_scheduler = SystemClockAttestationScheduler::new(
-            message_broadcaster,
+            Box::new(message_broadcaster),
             message_generator,
-            price_provider,
+            Box::new(price_provider),
             Some(1),
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,14 +22,14 @@ async fn main() -> Result<()> {
     gofer_cmd.push_str(" prices --norpc ETH/USD");
     log::debug!("Gofer command: {}", gofer_cmd);
 
-    let price_provider = GoferPriceProvider::new(&gofer_cmd);
+    let price_provider = Box::new(GoferPriceProvider::new(&gofer_cmd));
     log::info!("Initialized price_provider");
     // TODO: Replace with a signature provider that lets the operator use their validator key
     let signature_provider = PrivateKeySignatureProvider::random();
     log::info!("Initialized signature_provider");
     let message_generator = MessageGenerator::new(Box::new(signature_provider));
     log::info!("Initialized message_generator");
-    let message_broadcaster = HttpMessageBroadcaster::new()?;
+    let message_broadcaster = Box::new(HttpMessageBroadcaster::new()?);
     log::info!("Initialized message_roadcaster");
 
     let attestation_scheduler = SystemClockAttestationScheduler::new(


### PR DESCRIPTION
If the constructor creates the Box the lifetimes become more complicated
than when the constructor is passed a Box.