### PR TITLE
feat(attestation_scheduler): prefer generics

### DIFF
--- a/src/attestation_scheduler.rs
+++ b/src/attestation_scheduler.rs
@@ -51,18 +51,18 @@ async fn wait_until_next_slot() {
     .await;
 }
 
-pub struct SystemClockAttestationScheduler {
-    message_broadcaster: Box<dyn MessageBroadcaster>,
+pub struct SystemClockAttestationScheduler<A: MessageBroadcaster, B: PriceProvider> {
+    message_broadcaster: A,
     message_generator: MessageGenerator,
-    price_provider: Box<dyn PriceProvider>,
+    price_provider: B,
     slots_to_run: Arc<Mutex<Option<u64>>>,
 }
 
-impl SystemClockAttestationScheduler {
+impl<A: MessageBroadcaster, B: PriceProvider> SystemClockAttestationScheduler<A, B> {
     pub fn new(
-        message_broadcaster: Box<dyn MessageBroadcaster>,
+        message_broadcaster: A,
         message_generator: MessageGenerator,
-        price_provider: Box<dyn PriceProvider>,
+        price_provider: B,
         slots_to_run: Option<u64>,
     ) -> Self {
         Self {
@@ -223,9 +223,9 @@ mod tests {
             JsonFileMessageBroadcaster::new(Some("test_data/output".to_string())).unwrap();
 
         let attestation_scheduler = SystemClockAttestationScheduler::new(
-            Box::new(message_broadcaster),
+            message_broadcaster,
             message_generator,
-            Box::new(price_provider),
+            price_provider,
             Some(1),
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,14 +22,14 @@ async fn main() -> Result<()> {
     gofer_cmd.push_str(" prices --norpc ETH/USD");
     log::debug!("Gofer command: {}", gofer_cmd);
 
-    let price_provider = Box::new(GoferPriceProvider::new(&gofer_cmd));
+    let price_provider = GoferPriceProvider::new(&gofer_cmd);
     log::info!("Initialized price_provider");
     // TODO: Replace with a signature provider that lets the operator use their validator key
     let signature_provider = PrivateKeySignatureProvider::random();
     log::info!("Initialized signature_provider");
     let message_generator = MessageGenerator::new(Box::new(signature_provider));
     log::info!("Initialized message_generator");
-    let message_broadcaster = Box::new(HttpMessageBroadcaster::new()?);
+    let message_broadcaster = HttpMessageBroadcaster::new()?;
     log::info!("Initialized message_roadcaster");
 
     let attestation_scheduler = SystemClockAttestationScheduler::new(


### PR DESCRIPTION
Uses generics with bounds instead of dyn Box.